### PR TITLE
docs: fix mixed documentation rules source and target branch

### DIFF
--- a/docs/rules/ruleSourceBranchName.md
+++ b/docs/rules/ruleSourceBranchName.md
@@ -1,28 +1,30 @@
-# Pull Request (PR) Target Branch
+# Pull Request (PR) Source Branch
 
--   code: `src/ruleTargetBranch.ts`
+-   code: `src/ruleSourceBranchName.ts`
 -   rule failing output is: `warn` (⚠️ )
 
-Selecting the appropriate target branch for a pull request (PR) is important for a seamless integration process and maintaining an organized Git history. It ensures that changes are merged into the correct branch, avoiding potential conflicts or errors.
+Properly naming the source branch is important for maintaining a clean and manageable Git history, as well as for avoiding issues with Git synchronization and case-insensitive file systems (such as macOS).
 
--   **Default Branch as Target:** The target branch for the pull request **must be the default branch** of the project. This ensures a consistent flow and minimizes the risk of merging changes into the wrong branch.
+-   **Slash Limit:** The source branch name should contain no more than one slash (`/`). Multiple slashes can lead to complications, especially during Git synchronization.
 
--   **Why This Rule?** Using the default branch as the target for PRs maintains uniformity and order in our repository. It simplifies the process for contributors and maintainers alike, making it easier to manage the project's development.
+-   **Case Sensitivity:** The source branch name should be entirely in lowercase. Using uppercase letters can cause issues on case-insensitive file systems, making it difficult to switch branches or causing errors during cloning.
 
--   **Exceptions:** In certain situations, targeting a branch other than the default may be necessary. These cases should be rare and well-justified to avoid confusion and maintain the integrity of the project's codebase.
+-   **Why These Rules?** Adhering to these naming conventions ensures that our Git operations run smoothly across different operating systems and minimizes the risk of sync issues. It also makes it easier to understand the branch's purpose at a glance.
+
+-   **Exceptions:** While these are general guidelines, there may be exceptional cases where deviations are acceptable. However, it's advisable to stick to these rules for the sake of consistency and to avoid potential issues.
 
 ---
 
 ## Custom Configuration
 
-To disable this rule:
+Disable this rule:
 
 <!-- prettier-ignore -->
 ```yaml
     - name: DangerJS pull request linter
       uses: espressif/shared-github-dangerjs@v1
       with:
-        rule-target-branch: 'false'
+        rule-source-branch: 'false'
 ```
 
 ---

--- a/docs/rules/ruleTargetBranch.md
+++ b/docs/rules/ruleTargetBranch.md
@@ -3,28 +3,26 @@
 -   code: `src/ruleTargetBranch.ts`
 -   rule failing output is: `warn` (⚠️ )
 
-Properly naming the source branch is important for maintaining a clean and manageable Git history, as well as for avoiding issues with Git synchronization and case-insensitive file systems (such as macOS).
+Selecting the appropriate target branch for a pull request (PR) is important for a seamless integration process and maintaining an organized Git history. It ensures that changes are merged into the correct branch, avoiding potential conflicts or errors.
 
--   **Slash Limit:** The source branch name should contain no more than one slash (`/`). Multiple slashes can lead to complications, especially during Git synchronization.
+-   **Default Branch as Target:** The target branch for the pull request **must be the default branch** of the project. This ensures a consistent flow and minimizes the risk of merging changes into the wrong branch.
 
--   **Case Sensitivity:** The source branch name should be entirely in lowercase. Using uppercase letters can cause issues on case-insensitive file systems, making it difficult to switch branches or causing errors during cloning.
+-   **Why This Rule?** Using the default branch as the target for PRs maintains uniformity and order in our repository. It simplifies the process for contributors and maintainers alike, making it easier to manage the project's development.
 
--   **Why These Rules?** Adhering to these naming conventions ensures that our Git operations run smoothly across different operating systems and minimizes the risk of sync issues. It also makes it easier to understand the branch's purpose at a glance.
-
--   **Exceptions:** While these are general guidelines, there may be exceptional cases where deviations are acceptable. However, it's advisable to stick to these rules for the sake of consistency and to avoid potential issues.
+-   **Exceptions:** In certain situations, targeting a branch other than the default may be necessary. These cases should be rare and well-justified to avoid confusion and maintain the integrity of the project's codebase.
 
 ---
 
 ## Custom Configuration
 
-Disable this rule:
+To disable this rule:
 
 <!-- prettier-ignore -->
 ```yaml
     - name: DangerJS pull request linter
       uses: espressif/shared-github-dangerjs@v1
       with:
-        rule-source-branch: 'false'
+        rule-target-branch: 'false'
 ```
 
 ---


### PR DESCRIPTION
This PR addresses the mix-up in the documentation for the rules `ruleSourceBranchName` and `ruleTargetBranch`.

