### PR TITLE
change(rule-commit-messages): add "test:" to the default list of allowed types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,8 @@
 ---
+minimum_pre_commit_version: 3.3.0
 default_install_hook_types: [pre-commit, commit-msg]
+default_stages: [pre-commit]
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/README.md
+++ b/README.md
@@ -91,23 +91,23 @@ If your project has specific needs, Shared GitHub DangerJS can be configured to 
 
 **Here is complete list of configurable parameters:**
 
-| Parameter                                              | CI Variable                            | Type | Default value                                      |
-| ------------------------------------------------------ | -------------------------------------- | ---- | -------------------------------------------------- |
-| Enable rule PR Description                             | `rule-description`                     | str  | `"true"` (use `"false"` to disable this rule)      |
-| Enable rule PR Lint Commit Messages                    | `rule-commit-messages`                 | str  | `"true"` (use `"false"` to disable this rule)      |
-| Enable rule PR Size (changed lines)                    | `rule-size-lines`                      | str  | `"true"` (use `"false"` to disable this rule)      |
-| Enable rule PR Source branch name                      | `rule-source-branch`                   | str  | `"true"` (use `"false"` to disable this rule)      |
-| Enable rule PR Target branch name                      | `rule-target-branch`                   | str  | `"true"` (use `"false"` to disable this rule)      |
-| Enable rule PR Too Many Commits                        | `rule-max-commits`                     | str  | `"true"` (use `"false"` to disable this check)     |
-| Commit message allowed "Type"s                         | `commit-messages-types`                | str  | `"change,ci,docs,feat,fix,refactor,remove,revert"` |
-| Commit message maximum length "Body" line              | `commit-messages-max-body-line-length` | str  | `"100"`                                            |
-| Commit message maximum length "Summary"                | `commit-messages-max-summary-length`   | str  | `"72"`                                             |
-| Commit message minimum length "Summary"                | `commit-messages-min-summary-length`   | str  | `"20"`                                             |
-| Ignore sections of PR description when counting length | `description-ignore-sections`          | str  | `"related,release,breaking"`                       |
-| Maximum changed code lines in PR                       | `max-size-lines`                       | str  | `"1000"`                                           |
-| Maximum commits in PR (soft limit, throw `info`)       | `max-commits-info`                     | str  | `"2"`                                              |
-| Maximum commits in PR (hard limit, throw `warn`)       | `max-commits-warn`                     | str  | `"5"`                                              |
-| Minimum length of PR description                       | `description-min-length`               | str  | `"50"`                                             |
+| Parameter                                              | CI Variable                            | Type | Default value                                           |
+| ------------------------------------------------------ | -------------------------------------- | ---- | ------------------------------------------------------- |
+| Enable rule PR Description                             | `rule-description`                     | str  | `"true"` (use `"false"` to disable this rule)           |
+| Enable rule PR Lint Commit Messages                    | `rule-commit-messages`                 | str  | `"true"` (use `"false"` to disable this rule)           |
+| Enable rule PR Size (changed lines)                    | `rule-size-lines`                      | str  | `"true"` (use `"false"` to disable this rule)           |
+| Enable rule PR Source branch name                      | `rule-source-branch`                   | str  | `"true"` (use `"false"` to disable this rule)           |
+| Enable rule PR Target branch name                      | `rule-target-branch`                   | str  | `"true"` (use `"false"` to disable this rule)           |
+| Enable rule PR Too Many Commits                        | `rule-max-commits`                     | str  | `"true"` (use `"false"` to disable this check)          |
+| Commit message allowed "Type"s                         | `commit-messages-types`                | str  | `"change,ci,docs,feat,fix,refactor,remove,revert,test"` |
+| Commit message maximum length "Body" line              | `commit-messages-max-body-line-length` | str  | `"100"`                                                 |
+| Commit message maximum length "Summary"                | `commit-messages-max-summary-length`   | str  | `"72"`                                                  |
+| Commit message minimum length "Summary"                | `commit-messages-min-summary-length`   | str  | `"20"`                                                  |
+| Ignore sections of PR description when counting length | `description-ignore-sections`          | str  | `"related,release,breaking"`                            |
+| Maximum changed code lines in PR                       | `max-size-lines`                       | str  | `"1000"`                                                |
+| Maximum commits in PR (soft limit, throw `info`)       | `max-commits-info`                     | str  | `"2"`                                                   |
+| Maximum commits in PR (hard limit, throw `warn`)       | `max-commits-warn`                     | str  | `"5"`                                                   |
+| Minimum length of PR description                       | `description-min-length`               | str  | `"50"`                                                  |
 
 These values can be defined in your project `DangerJS Pull Request linter` workflow, for example like this:
 

--- a/src/configParameters.ts
+++ b/src/configParameters.ts
@@ -15,7 +15,7 @@ const defaults = {
 	prDescription: { enabled: true, minLength: 50, ignoredSections: 'related,release,breaking' },
 	commitMessages: {
 		enabled: true,
-		allowedTypes: 'change,ci,docs,feat,fix,refactor,remove,revert',
+		allowedTypes: 'change,ci,docs,feat,fix,refactor,remove,revert,test',
 		minSummaryLength: 20,
 		maxSummaryLength: 72,
 		maxBodyLineLength: 100,

--- a/tests/ruleCommitMessages.test.ts
+++ b/tests/ruleCommitMessages.test.ts
@@ -26,12 +26,6 @@ describe('TESTS: Commit messages style', () => {
 			jest.doMock('../src/configParameters', () => ({
 				config: {
 					...originalConfig,
-					commitMessages: {
-						maxBodyLineLength: 100,
-						maxSummaryLength: 72,
-						minSummaryLength: 20,
-						allowedTypes: 'change,ci,docs,feat,fix,refactor,remove,revert',
-					},
 				},
 				recordRuleExitStatus,
 			}));
@@ -40,6 +34,12 @@ describe('TESTS: Commit messages style', () => {
 
 		it('EXPECT PASS: Message with "scope" and "body"', async () => {
 			danger.git.commits = [{ message: 'feat(bootloader): This is commit message with scope and body\n\nThis is a text of body' }];
+			await ruleCommitMessages();
+			expect(warn).not.toHaveBeenCalled();
+		});
+
+		it('EXPECT PASS: Message with "scope" and "body", type "test"', async () => {
+			danger.git.commits = [{ message: 'test(bootloader): This is commit message with scope and body\n\nThis is a text of body' }];
 			await ruleCommitMessages();
 			expect(warn).not.toHaveBeenCalled();
 		});


### PR DESCRIPTION
Adding commit type test:  (Adding missing tests or correcting existing tests, test script changes) to default allowed types

## Related
- https://github.com/espressif/conventional-precommit-linter/pull/19